### PR TITLE
Pipeline: transport_test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,7 +287,7 @@ jobs:
         wait $cli_pid
         echo "Client finished OK (logs will be uploaded as artifacts)."
 
-    - name: Upload logs: [transport_test - All modes]
+    - name: Upload logs for [transport_test - All modes]
       uses: actions/upload-artifact@v3
       with:
         name: ipc-transport-test-run-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,15 +212,13 @@ jobs:
     # TODO: Ideally let our CMake interrogate jemalloc-config to find jemalloc-prefix itself.
     # Less stuff for us to worry about that way here.  If it has not been tried, try it.
     # If it does not work, apply a small effort to see if it can be easily made to work.
-    #
-    # TODO: It seems unusual to place install-prefix inside build-prefix.
     - name: Prepare Makefile using CMake
       run: |
         cmake \
           --preset ${{ matrix.build-type.conan-preset }} \
           -DCFG_ENABLE_TEST_SUITE=ON \
           -DJEMALLOC_PREFIX=je_ \
-          -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install 
+          -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}
 
     - name: Build targets (libraries, demos/tests) with Makefile
       run: |
@@ -237,45 +235,45 @@ jobs:
             
     - name: Run link test [`ipc_core` - Flow-IPC Core]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_core_link_test.exec
 
     - name: Run link test [`ipc_transport_structured` - Flow-IPC Structured Transport]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_transport_structured_link_test.exec
 
     # Server will exit automatically (same below).
     - name: Run link test [`ipc_session` - Flow-IPC Sessions]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_session_link_test_srv.exec & 
         sleep 1
         ./ipc_session_link_test_cli.exec
 
     - name: Run link test [`ipc_shm` - Flow-IPC Shared Memory]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_shm_link_test_srv.exec & 
         sleep 1
         ./ipc_shm_link_test_cli.exec
         
     - name: Run link test [`ipc_shm_arena_lend` - Flow-IPC SHM-jemalloc]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_shm_arena_lend_link_test_srv.exec & 
         sleep 1
         ./ipc_shm_arena_lend_link_test_cli.exec
 
     - name: Run unit tests
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./libipc_unit_test.exec
 
     # This follows the instructions in bin/transport_test/README.txt.
     - name: Run integration test [transport_test - Scripted mode]
       run: |
-        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin/transport_test
+        cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin/transport_test
         mkdir -p runs/scripted
         ./transport_test.exec scripted runs/scripted/transport_test.srv.log info info \
           < srv-script.txt > runs/scripted/transport_test.srv.console.log 2>&1 &
@@ -294,7 +292,7 @@ jobs:
       with:
         name: ipc-transport-test-run-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}
         path: |
-          ${{ github.workspace }}/build/${{ matrix.build-type.conan-name }}/install/bin/transport_test/runs
+          ${{ github.workspace }}/install/${{ matrix.build-type.conan-name }}/bin/transport_test/runs
 
 # TODO: Look into the topic of debuggability in case of a crash.  Is a core generated?  Is it saved?
 # Do we need to manually save it as an artifact?  For that matter we would then need the binary and

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -269,3 +269,36 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin
         ./libipc_unit_test.exec
+
+    # This follows the instructions in bin/transport_test/README.txt.
+    - name: Run integration test [transport_test - Scripted mode]
+      run: |
+        cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin/transport_test
+        mkdir -p runs/scripted
+        ./transport_test.exec scripted runs/scripted/transport_test.srv.log info info |
+          < srv-script.txt > runs/scripted/transport_test.srv.console.log 2>&1 &
+        srv_pid=$!
+        sleep 1
+        ./transport_test.exec scripted runs/scripted/transport_test.cli.log info info |
+          < cli-script.txt > runs/scripted/transport_test.cli.console.log 2>&1 &
+        cli_pid=$!
+        wait $srv_pid
+        echo "Server finished OK (logs will be uploaded as artifacts)."
+        wait $cli_pid
+        echo "Client finished OK (logs will be uploaded as artifacts)."
+
+    - name: Upload logs: [transport_test - All modes]
+      uses: actions/upload-artifact@v3
+      with:
+        name: ipc-transport-test-run-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}
+        path: |
+          ${{ github.workspace }}/build/${{ matrix.build-type.conan-name }}/install/bin/transport_test/runs
+
+# TODO: Look into the topic of debuggability in case of a crash.  Is a core generated?  Is it saved?
+# Do we need to manually save it as an artifact?  For that matter we would then need the binary and
+# ideally the source.  For now we save any logs that are not printed to console, and where possible
+# our demos/tests keep it the console exclusively (but in some cases, such as transport_test, it
+# is not practical due to parallel execution and other aspects).  In general it is always better that
+# logs are sufficient; but look into situations where they are not.
+#
+# Possibly this is all handled beautifully automatically; then this should be deleted.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -287,7 +287,9 @@ jobs:
         wait $cli_pid
         echo "Client finished OK (logs will be uploaded as artifacts)."
 
+    # Upload even if something failed before; it can help diagnose.
     - name: Upload logs for [transport_test - All modes]
+      if: ${{ always() }}
       uses: actions/upload-artifact@v3
       with:
         name: ipc-transport-test-run-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Just pick one that's pre-installed and reasonably new.
         compiler:
           - { id: clang-15, name: clang, version: 15, c-path: /usr/bin/clang-15, cpp-path: /usr/bin/clang++-15 }
         build-type:
@@ -142,7 +143,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    
+
+    # Many compilers are pre-installed; if not then fetch it.
     - name: Install clang compiler
       run: |
         wget https://apt.llvm.org/llvm.sh
@@ -275,11 +277,11 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }}/install/bin/transport_test
         mkdir -p runs/scripted
-        ./transport_test.exec scripted runs/scripted/transport_test.srv.log info info |
+        ./transport_test.exec scripted runs/scripted/transport_test.srv.log info info \
           < srv-script.txt > runs/scripted/transport_test.srv.console.log 2>&1 &
         srv_pid=$!
         sleep 1
-        ./transport_test.exec scripted runs/scripted/transport_test.cli.log info info |
+        ./transport_test.exec scripted runs/scripted/transport_test.cli.log info info \
           < cli-script.txt > runs/scripted/transport_test.cli.console.log 2>&1 &
         cli_pid=$!
         wait $srv_pid

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  # Make it possible to trigger workflow manually.
   workflow_dispatch:
   
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,19 +232,25 @@ jobs:
         VERBOSE=1 make install \
           --directory $GITHUB_WORKSPACE/build/${{ matrix.build-type.conan-name }} \
           -j${{ steps.cpu-cores.outputs.count }}
-            
+
+    # From now on use always() to try to run any demo/test that exists regardless
+    # of preceding failures if any.  Same with the log-upload at the end.
+
     - name: Run link test [`ipc_core` - Flow-IPC Core]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_core_link_test.exec
 
     - name: Run link test [`ipc_transport_structured` - Flow-IPC Structured Transport]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_transport_structured_link_test.exec
 
     # Server will exit automatically (same below).
     - name: Run link test [`ipc_session` - Flow-IPC Sessions]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_session_link_test_srv.exec & 
@@ -252,6 +258,7 @@ jobs:
         ./ipc_session_link_test_cli.exec
 
     - name: Run link test [`ipc_shm` - Flow-IPC Shared Memory]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_shm_link_test_srv.exec & 
@@ -259,6 +266,7 @@ jobs:
         ./ipc_shm_link_test_cli.exec
         
     - name: Run link test [`ipc_shm_arena_lend` - Flow-IPC SHM-jemalloc]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./ipc_shm_arena_lend_link_test_srv.exec & 
@@ -266,12 +274,14 @@ jobs:
         ./ipc_shm_arena_lend_link_test_cli.exec
 
     - name: Run unit tests
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin
         ./libipc_unit_test.exec
 
     # This follows the instructions in bin/transport_test/README.txt.
     - name: Run integration test [transport_test - Scripted mode]
+      if: always()
       run: |
         cd $GITHUB_WORKSPACE/install/${{ matrix.build-type.conan-name }}/bin/transport_test
         mkdir -p runs/scripted
@@ -287,9 +297,8 @@ jobs:
         wait $cli_pid
         echo "Client finished OK (logs will be uploaded as artifacts)."
 
-    # Upload even if something failed before; it can help diagnose.
     - name: Upload logs for [transport_test - All modes]
-      if: ${{ always() }}
+      if: always()
       uses: actions/upload-artifact@v3
       with:
         name: ipc-transport-test-run-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,7 @@ jobs:
         build-type:
           - { id: release, conan-name: Release, conan-preset: release }
 
-    # EXPERIMENTAL!  DO NOT PUSH!  Use larger runner.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
         
     name: |
       doc-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}
@@ -131,8 +130,7 @@ jobs:
           - { id: relwithdebinfo, conan-name: RelWithDebInfo, conan-jemalloc: Release, conan-preset: relwithdebinfo }
           - { id: minsizerel, conan-name: MinSizeRel, conan-jemalloc: Release, conan-preset: minsizerel}
 
-    # EXPERIMENTAL!  DO NOT PUSH!  Use larger runner.
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
         
     name: |
       build-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
         build-type:
           - { id: release, conan-name: Release, conan-preset: release }
 
-    runs-on: ubuntu-latest
+    # EXPERIMENTAL!  DO NOT PUSH!  Use larger runner.
+    runs-on: ubuntu-latest-m
         
     name: |
       doc-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}
@@ -130,7 +131,8 @@ jobs:
           - { id: relwithdebinfo, conan-name: RelWithDebInfo, conan-jemalloc: Release, conan-preset: relwithdebinfo }
           - { id: minsizerel, conan-name: MinSizeRel, conan-jemalloc: Release, conan-preset: minsizerel}
 
-    runs-on: ubuntu-latest
+    # EXPERIMENTAL!  DO NOT PUSH!  Use larger runner.
+    runs-on: ubuntu-latest-m
         
     name: |
       build-${{ matrix.compiler.id }}-${{ matrix.build-type.id }}

--- a/test/suite/transport_test/cli-script.txt
+++ b/test/suite/transport_test/cli-script.txt
@@ -92,10 +92,10 @@ BLOB_STREAM_MQ_BIPC_SEND_BLOB 0 8 0
 # Should would-block around here due to opposing sleep.
 BLOB_STREAM_MQ_BIPC_SEND_BLOB 0 8 0
 BLOB_STREAM_MQ_BIPC_SEND_BLOB 0 8 0
-# End with graceful-close.  It's take > the time opposing side will sleep for that to report end-sending done:
+# End with graceful-close.  It'd take > the time opposing side will sleep for that to report end-sending done:
 # thus we test graceful-close queueing (would-block) and reporting thereof.
 # <cmd> <stm-slot> <dupe-call?> <expected-ipc-err-or-success> <timeout> <timeout-units>
-BLOB_STREAM_MQ_BIPC_SEND_END 0 0 0 2100 ms
+BLOB_STREAM_MQ_BIPC_SEND_END 0 0 0 2500 ms
 # And a lame dupe.
 BLOB_STREAM_MQ_BIPC_SEND_END 0 1 0 0 s
 


### PR DESCRIPTION
Adding transport_test scripted mode to workflow. Console logs x 2 and ipc/flow-logs x 2 are uploaded as artifacts.

- transport_test scripted-mode pipeline run: Sporadic failure due to a timeout - Loosening a timeout by some milliseconds.

Opportunistic: Doing TODO which said to avoid putting install-path inside build-path. Still following Conan preset behavior which appends the build-type at the end of the prefix (so it will be build/BLAHHHH still but also install/BLAHHHH now instead of build/BLAHHHH/install).

Upload logs even if preceding test failed (especially if!).

Similarly for running the tests.

Minor: added cmnt.
