### PR TITLE
transport_test-scripted failed once in GitHub workflow - tight timeou…

### DIFF
--- a/test/suite/transport_test/srv-script.txt
+++ b/test/suite/transport_test/srv-script.txt
@@ -107,6 +107,13 @@ BLOB_STREAM_MQ_BIPC_SND_CREATE _mqd_0 0 0 0 0 0
 
 # Let's actually do some IPC (between processes).
 
+# Note: There are very tight timeouts below -- in "microseconds" -- and the idea is to ensure
+# it doesn't block at all in situations, e.g., where we know there are N messages queued-up
+# locally at that point.  However the actual time depends on computer speed, and on slower machines
+# like default GitHub runners it can take longer than one experiences in a powerful lab machine.
+# We are not benchmarking here or perf-testing, so to avoid false failures we use a less tight
+# timeout that's still in the microseconds.  So 50usec is realistic usually, but we use 250usec.
+
 BLOB_STREAM_MQ_POSIX_RCV_CREATE _mqd_1 1 3 10 0 0
 # -> Posix: rcv 2
 # <cmd> <stm-slot> <blob-sz> <expected-ipc-err-or-success> <expected-blob-sz>
@@ -118,21 +125,21 @@ BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 9 2 s
 # And then immediately this (hence short timeout).
 # This one will probably test *surplus*; but best to test it separately
 # next.
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 50 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 250 microseconds
 # They'll send 5 more quickly; we will wait and *then* receive.  ~2 of those should would-block on the send-side
 # which will exercise that (typically rarely exercised) logic.
 # Tests receive-side *surplus* and send-side *would-block*.
 SLEEP 2 s
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 50 microseconds
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 50 microseconds
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 50 microseconds
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 50 microseconds
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 50 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 250 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 250 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 250 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 10 250 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 10 0 1 250 microseconds
 # Try too-small *versus MQ requirement that rcv buf always be big-enough to receive the biggest possible msg* receive
 # buffer -- regardless of actual message size it should fail but not fatally, with INVALID_ARGUMENT.
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 9 INVALID_ARGUMENT 0 50 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 9 INVALID_ARGUMENT 0 250 microseconds
 # Pipe OK given large enough buffer size this time.  In fact let's use a bigger-than-needed one for fun.
-BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 11 0 5 50 microseconds
+BLOB_STREAM_MQ_POSIX_RECV_BLOB 2 11 0 5 250 microseconds
 
 SLEEP 1 s
 


### PR DESCRIPTION
…ts - Increasing timeouts (still in usec but higher to match GitHub runners which are slower.