### PR TITLE
A very-sporadic transport_test-ex-heap TSAN warning similar to one a couple months ago; very-likely false-positive regarding race accessing an FD; suppressing.  Resolves issue #92.

### DIFF
--- a/test/suite/transport_test/heap/sanitize/tsan/suppressions_clang.cfg
+++ b/test/suite/transport_test/heap/sanitize/tsan/suppressions_clang.cfg
@@ -86,3 +86,49 @@
 #
 # In the meantime suppress the issue at a few frames up from the reported problem.  Hopefully that takes care of it.
 race:boost::asio::detail::epoll_reactor::~epoll_reactor
+
+# I have seen this warning exactly once as of this writing, with clang-16.  Upon careful analysis: it's got to be
+# a false positive.  It looks like this:
+#   WARNING: ThreadSanitizer: data race (pid=77766)
+#     Read of size 8 at 0x7bb000000b00 by thread T2 (mutexes: write M0):
+#       #0 epoll_ctl <null> (ex_srv.exec+0xaaed6)
+#       #1 boost::asio::detail::epoll_reactor::deregister_descriptor(...) .../include/boost/asio/detail/impl/epoll_reactor.ipp:403:7 (ex_srv.exec+0x191833)
+#   ...
+#       #4 ipc::util::sync_io::Asio_waitable_native_handle::~Asio_waitable_native_handle() /home/runner/work/ipc/ipc/ipc_core/src/ipc/util/sync_io/asio_waitable_native_hndl.cpp:53:3 (ex_srv.exec+0xcd7079)
+#       #5 ipc::transport::sync_io::Native_socket_stream::Impl::~Impl() /home/runner/work/ipc/ipc/ipc_core/src/ipc/transport/sync_io/detail/native_socket_stream_impl.cpp:179:1 (ex_srv.exec+0xcfe8b8)
+#   ...
+#       #24 ipc::session::Server_session_impl<(capnp::schemas::MqType_b8e35b936cc1fb36)2, true, ipc::transport::test::capnp::ExMdt, (capnp::schemas::ShmType_9f81320797229579)0, 0ul, false>::~Server_session_impl() /home/runner/work/ipc/ipc/ipc_session/src/ipc/session/detail/server_session_impl.hpp:826:1 (ex_srv.exec+0x282735)
+#   ...
+#       #34 ipc::transport::test::Ex_srv<ipc::session::Session_server<(capnp::schemas::MqType_b8e35b936cc1fb36)2, true, ipc::transport::test::capnp::ExMdt>, false>::App_session::~App_session() /home/runner/work/ipc/ipc/test/suite/transport_test/ex_srv.hpp:65:9 (ex_srv.exec+0x275322)
+#   ...
+#     Previous write of size 8 at 0x7bb000000b00 by thread T79:
+#       #0 eventfd <null> (ex_srv.exec+0xa8eeb)
+#       #1 boost::asio::detail::eventfd_select_interrupter::open_descriptors() .../include/boost/asio/detail/impl/eventfd_select_interrupter.ipp:59:5 (ex_srv.exec+0x16fa16)
+#   ...
+#       #16 ipc::transport::sync_io::Blob_stream_mq_sender_impl<ipc::transport::Bipc_mq_handle>::Blob_stream_mq_sender_impl(flow::log::Logger*, flow::util::Basic_string_view<char, std::char_traits<char>>, ipc::transport::Bipc_mq_handle&&, boost::system::error_code*) /home/runner/work/ipc/ipc/ipc_core/src/ipc/transport/sync_io/detail/blob_stream_mq_snd_impl.hpp:649:3 (ex_srv.exec+0x1aa002)
+#       #21 ipc::session::Server_session_impl<(capnp::schemas::MqType_b8e35b936cc1fb36)2, true, ipc::transport::test::capnp::ExMdt, (capnp::schemas::ShmType_9f81320797229579)0, 0ul, false>::create_channel_and_resources(ipc::util::Shared_name*, ipc::util::Shared_name*, ipc::util::Native_handle*, ipc::transport::Mqs_socket_stream_channel<true, ipc::transport::Bipc_mq_handle>*, bool) /home/runner/work/ipc/ipc/ipc_session/src/ipc/session/detail/server_session_impl.hpp:1429:26 (ex_srv.exec+0x2b0c8a)
+#       #22 void ipc::session::Server_session_impl<(capnp::schemas::MqType_b8e35b936cc1fb36)2, true, ipc::transport::test::capnp::ExMdt, (capnp::schemas::ShmType_9f81320797229579)0, 0ul, false>::async_accept_log_in...lambda... server_session_impl.hpp:2004:16
+#   ...
+#     Location is file descriptor 88 created by thread T79 at:
+#   ...(exact same stack trace as the immediately preceding one, for "Previous write of size 8 at 0x7bb000000b00 by thread T79")...
+#     Thread T2 'guy' (tid=77770, running) created by main thread at:
+#   ...
+#     Thread T79 '0x7b7c00012600]' (tid=77923, running) created by thread T5 at:
+#   ...
+#   SUMMARY: ThreadSanitizer: data race (/home/runner/bin/ex_srv.exec+0xaaed6) (BuildId: 0118b0aeb45f6a52d5750c9f17ba086797a3fc3e) in epoll_ctl
+# This looks quite similar to the preceding false-positive: same threads involved albeit in opposite order.  Still,
+# the later op (the one causing the warning) is just deregistering an FD from an epoll set, due to (ultimately) the fact
+# up-stack the transport_test App_session, therefore the Server_session, dtor is being invoked by transport_test.
+# The alleged previous, racing use is: Somewhat earlier, in indeed Server_session's internal thread W (T79 here),
+# when that guy was going through the usual session log-in, including ::create_channel_and_resources(), where it was
+# pre-opening the desired channel(s) including in this case a bipc-type MQ.  Admittedly, it is not totally clear why
+# this FD 88 is the same FD: The session-creation one pertains to the bipc-type MQ (looks like internal boost.asio
+# epoll book-keeping via ::eventfd() mechanism), while the session-destruction one pertains to the
+# internal-use session-master-channel local socket stream.  Surely we can figure out the details, but in the bigger
+# picture it's all legit, as far as I can tell: Perhaps that FD got closed and then reused (which is how it works
+# in Unixes generally).  Similarly to the preceding false-positive, it looks like a false-positive.  So:
+# TODO: Try to reproduce and debug.  Won't be easy; again I've only seen it once.  Do note that the test completed
+# fine even then (but that doesn't in itself prove there's no race of course).
+#
+# In the meantime suppress the issue at a few frames up from the reported problem.  Hopefully that takes care of it.
+race:boost::asio::detail::epoll_reactor::deregister_descriptor


### PR DESCRIPTION
(resolves #92)