### PR TITLE
Dependency bump: Boost v1.84 to 1.87: Update CI pipeline. / Updating submodules.  Pulls in: [flow] Dependency bump: Boost v1.84 to 1.87. Results in slight breaking API changes in flow::error. (Details in Description.) / Comment and/or doc changes. | [ipc_core] Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module. / Bug fix in Bipc_mq_handle wait-based APIs exception-throwing form. | [ipc_transport_structured] Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module. / Boost v1.84 to 1.87 in Flow => fix Boost.uuid use due to changed API. | [ipc_session] Boost v1.84 to 1.87 in Flow => slight breaking API changes in flow::error => fix/improve their use in this module.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -733,6 +733,10 @@ jobs:
       run: |
         # Install Flow-IPC dependencies with Conan using the profile.
         ${{ env.setup-run-env }}
+        # Next 3 lines: Must do same as flow's main.yml; see that code.
+        # TODO: See the TODO there which applies to these lines.
+        NON_REMOTE_BOOST_VER=1.87
+        conan export ./flow/conan/boost/$NON_REMOTE_BOOST_VER boost/$NON_REMOTE_BOOST_VER.0@
         FLOW_VERSION=`cat flow/VERSION`
         conan editable add flow flow/$FLOW_VERSION
         # At least `configure` mini-programs are built with our build-settings, so $BUILD_CMD_PREFIX is required.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -933,7 +933,7 @@ jobs:
     - name: Run unit tests
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: |
         # Run unit tests.
         cd ${{ env.install-dir }}/bin
@@ -1041,7 +1041,7 @@ jobs:
     - name: Run integration test [perf_demo - SHM-jemalloc mode]
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_perf_demo.sh shm_jemalloc
 
     # For tests below where on failure it can be very helpful to look at higher-verbosity logs,
@@ -1061,7 +1061,7 @@ jobs:
     - name: Prepare run script for [transport_test - Scripted mode] variations below
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Scripted mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_sc.sh
@@ -1096,13 +1096,13 @@ jobs:
       id: transport_test_scripted
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh info
 
     - name: Re-run with increased logging, on failure only
       if: |
         false
-        # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
+      # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh data
 
     # The following [Exercise mode] tests follow the instructions in bin/transport_test/README.txt.
@@ -1113,7 +1113,7 @@ jobs:
     - name: Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode]
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: |
         # Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode].
         mkdir -p ~/bin/ex_srv_run ~/bin/ex_cli_run
@@ -1125,7 +1125,7 @@ jobs:
     - name: Prepare run script for [transport_test - Exercise mode] variations below
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Exercise mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_ex.sh
@@ -1172,26 +1172,26 @@ jobs:
       id: transport_test_ex_heap
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info heap
 
     - name: Re-run with increased logging, on failure only
       if: |
         false
-        # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
+      # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data heap_log_level_data
 
     - name: Run integration test [transport_test - Exercise mode - SHM-classic sub-mode]
       id: transport_test_ex_shm_c
       if: |
         false
-        # XXX !cancelled()
+      # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_classic -shm-c
 
     - name: Re-run with increased logging, on failure only
       if: |
         false
-        # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
+      # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_classic_log_level_data -shm-c
 
     # Disabling this particular test run for the specific case of clang-17 in TSAN (thread sanitizer) config
@@ -1224,20 +1224,20 @@ jobs:
       id: transport_test_ex_shm_j
       if: |
         false
-        # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
+      # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_jemalloc -shm-j
 
     - name: Re-run with increased logging, on failure only
       if: |
         false
-        # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
+      # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_jemalloc_log_level_data -shm-j
 
     # See earlier comment block about why we saved all the logs including for console-output-only tests/demos.
     - name: Check test/demo logs for non-fatal sanitizer error(s)
       if: |
         false
-        # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
+      # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
       run: |
         cd ${{ env.install-dir }}/bin/logs
         # grep returns 0 if 1+ found, 1 if none found, 2+ on error.  So check results explicitly instead of -e.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -932,7 +932,8 @@ jobs:
 
     - name: Run unit tests
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: |
         # Run unit tests.
         cd ${{ env.install-dir }}/bin
@@ -1039,7 +1040,8 @@ jobs:
 
     - name: Run integration test [perf_demo - SHM-jemalloc mode]
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_perf_demo.sh shm_jemalloc
 
     # For tests below where on failure it can be very helpful to look at higher-verbosity logs,
@@ -1058,7 +1060,8 @@ jobs:
     # This follows the instructions in bin/transport_test/README.txt.
     - name: Prepare run script for [transport_test - Scripted mode] variations below
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Scripted mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_sc.sh
@@ -1092,12 +1095,14 @@ jobs:
     - name: Run integration test [transport_test - Scripted mode]
       id: transport_test_scripted
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh info
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
+        false
+        # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh data
 
     # The following [Exercise mode] tests follow the instructions in bin/transport_test/README.txt.
@@ -1107,7 +1112,8 @@ jobs:
 
     - name: Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode]
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: |
         # Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode].
         mkdir -p ~/bin/ex_srv_run ~/bin/ex_cli_run
@@ -1118,7 +1124,8 @@ jobs:
 
     - name: Prepare run script for [transport_test - Exercise mode] variations below
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Exercise mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_ex.sh
@@ -1164,23 +1171,27 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - Heap sub-mode]
       id: transport_test_ex_heap
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info heap
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
+        false
+        # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data heap_log_level_data
 
     - name: Run integration test [transport_test - Exercise mode - SHM-classic sub-mode]
       id: transport_test_ex_shm_c
       if: |
-        false # XXX !cancelled()
+        false
+        # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_classic -shm-c
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
+        false
+        # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_classic_log_level_data -shm-c
 
     # Disabling this particular test run for the specific case of clang-17 in TSAN (thread sanitizer) config
@@ -1212,18 +1223,21 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - SHM-jemalloc sub-mode]
       id: transport_test_ex_shm_j
       if: |
-        false # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
+        false
+        # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_jemalloc -shm-j
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
+        false
+        # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_jemalloc_log_level_data -shm-j
 
     # See earlier comment block about why we saved all the logs including for console-output-only tests/demos.
     - name: Check test/demo logs for non-fatal sanitizer error(s)
       if: |
-        false # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
+        false
+        # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
       run: |
         cd ${{ env.install-dir }}/bin/logs
         # grep returns 0 if 1+ found, 1 if none found, 2+ on error.  So check results explicitly instead of -e.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -457,7 +457,9 @@ jobs:
           - compiler: { id: gcc-11 }
           - compiler: { id: gcc-13 }
           - compiler: { id: clang-13 }
-          # - build-test-cfg: { id: debug }
+          - compiler: { id: clang-15 }
+          - build-test-cfg: { id: debug }
+          - build-test-cfg: { id: minsizerel }          
           - build-test-cfg: { id: relwithdebinfo }
           - build-test-cfg: { id: relwithdebinfo-asan }
           - build-test-cfg: { id: relwithdebinfo-ubsan }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -451,19 +451,6 @@ jobs:
             build-test-cfg: { id: relwithdebinfo-tsan }
           - compiler: { id: clang-13 }
             build-test-cfg: { id: relwithdebinfo-tsan }
-          # XXX
-          - compiler: { id: gcc-9 }
-          - compiler: { id: gcc-10 }
-          - compiler: { id: gcc-11 }
-          - compiler: { id: gcc-13 }
-          - compiler: { id: clang-13 }
-          - compiler: { id: clang-15 }
-          - build-test-cfg: { id: debug }
-          - build-test-cfg: { id: minsizerel }          
-          - build-test-cfg: { id: relwithdebinfo }
-          - build-test-cfg: { id: relwithdebinfo-asan }
-          - build-test-cfg: { id: relwithdebinfo-ubsan }
-          - build-test-cfg: { id: relwithdebinfo-tsan }
 
     # Not using ubuntu-latest, so as to avoid surprises with OS upgrades and such.
     runs-on: ubuntu-22.04
@@ -934,8 +921,7 @@ jobs:
 
     - name: Run unit tests
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: |
         # Run unit tests.
         cd ${{ env.install-dir }}/bin
@@ -1042,8 +1028,7 @@ jobs:
 
     - name: Run integration test [perf_demo - SHM-jemalloc mode]
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_perf_demo.sh shm_jemalloc
 
     # For tests below where on failure it can be very helpful to look at higher-verbosity logs,
@@ -1062,8 +1047,7 @@ jobs:
     # This follows the instructions in bin/transport_test/README.txt.
     - name: Prepare run script for [transport_test - Scripted mode] variations below
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: |
         # Prepare run script for [transport_test - Scripted mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_sc.sh
@@ -1097,14 +1081,12 @@ jobs:
     - name: Run integration test [transport_test - Scripted mode]
       id: transport_test_scripted
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh info
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false
-      # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
+        (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh data
 
     # The following [Exercise mode] tests follow the instructions in bin/transport_test/README.txt.
@@ -1114,8 +1096,7 @@ jobs:
 
     - name: Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode]
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: |
         # Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode].
         mkdir -p ~/bin/ex_srv_run ~/bin/ex_cli_run
@@ -1126,8 +1107,7 @@ jobs:
 
     - name: Prepare run script for [transport_test - Exercise mode] variations below
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: |
         # Prepare run script for [transport_test - Exercise mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_ex.sh
@@ -1173,27 +1153,23 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - Heap sub-mode]
       id: transport_test_ex_heap
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info heap
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false
-      # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
+        (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data heap_log_level_data
 
     - name: Run integration test [transport_test - Exercise mode - SHM-classic sub-mode]
       id: transport_test_ex_shm_c
       if: |
-        false
-      # XXX !cancelled()
+        !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_classic -shm-c
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false
-      # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
+        (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_classic_log_level_data -shm-c
 
     # Disabling this particular test run for the specific case of clang-17 in TSAN (thread sanitizer) config
@@ -1225,21 +1201,18 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - SHM-jemalloc sub-mode]
       id: transport_test_ex_shm_j
       if: |
-        false
-      # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
+        (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_jemalloc -shm-j
 
     - name: Re-run with increased logging, on failure only
       if: |
-        false
-      # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
+        (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_jemalloc_log_level_data -shm-j
 
     # See earlier comment block about why we saved all the logs including for console-output-only tests/demos.
     - name: Check test/demo logs for non-fatal sanitizer error(s)
       if: |
-        false
-      # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
+        (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
       run: |
         cd ${{ env.install-dir }}/bin/logs
         # grep returns 0 if 1+ found, 1 if none found, 2+ on error.  So check results explicitly instead of -e.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -457,7 +457,7 @@ jobs:
           - compiler: { id: gcc-11 }
           - compiler: { id: gcc-13 }
           - compiler: { id: clang-13 }
-          - build-test-cfg: { id: debug }
+          # - build-test-cfg: { id: debug }
           - build-test-cfg: { id: relwithdebinfo }
           - build-test-cfg: { id: relwithdebinfo-asan }
           - build-test-cfg: { id: relwithdebinfo-ubsan }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -451,6 +451,17 @@ jobs:
             build-test-cfg: { id: relwithdebinfo-tsan }
           - compiler:  { id: clang-13 }
             build-test-cfg: { id: relwithdebinfo-tsan }
+          # XXX
+          - compiler:  { id: gcc-9 }
+          - compiler:  { id: gcc-10 }
+          - compiler:  { id: gcc-11 }
+          - compiler:  { id: gcc-13 }
+          - compiler:  { id: clang-13 }
+          - build-test-cfg: { id: debug }
+          - build-test-cfg: { id: relwithdebinfo }
+          - build-test-cfg: { id: relwithdebinfo-asan }
+          - build-test-cfg: { id: relwithdebinfo-ubsan }
+          - build-test-cfg: { id: relwithdebinfo-tsan }
 
     # Not using ubuntu-latest, so as to avoid surprises with OS upgrades and such.
     runs-on: ubuntu-22.04
@@ -921,7 +932,7 @@ jobs:
 
     - name: Run unit tests
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: |
         # Run unit tests.
         cd ${{ env.install-dir }}/bin
@@ -1028,7 +1039,7 @@ jobs:
 
     - name: Run integration test [perf_demo - SHM-jemalloc mode]
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_perf_demo.sh shm_jemalloc
 
     # For tests below where on failure it can be very helpful to look at higher-verbosity logs,
@@ -1047,7 +1058,7 @@ jobs:
     # This follows the instructions in bin/transport_test/README.txt.
     - name: Prepare run script for [transport_test - Scripted mode] variations below
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Scripted mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_sc.sh
@@ -1081,12 +1092,12 @@ jobs:
     - name: Run integration test [transport_test - Scripted mode]
       id: transport_test_scripted
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh info
 
     - name: Re-run with increased logging, on failure only
       if: |
-        (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
+        false # XXX (!cancelled()) && (steps.transport_test_scripted.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_sc.sh data
 
     # The following [Exercise mode] tests follow the instructions in bin/transport_test/README.txt.
@@ -1096,7 +1107,7 @@ jobs:
 
     - name: Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode]
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: |
         # Prepare IPC-session safety-friendly run-time environment for [transport_test - Exercise mode].
         mkdir -p ~/bin/ex_srv_run ~/bin/ex_cli_run
@@ -1107,7 +1118,7 @@ jobs:
 
     - name: Prepare run script for [transport_test - Exercise mode] variations below
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: |
         # Prepare run script for [transport_test - Exercise mode] variations below.
         cat <<'EOF' > ${{ env.install-dir }}/bin/run_transport_test_ex.sh
@@ -1153,23 +1164,23 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - Heap sub-mode]
       id: transport_test_ex_heap
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info heap
 
     - name: Re-run with increased logging, on failure only
       if: |
-        (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
+        false # XXX (!cancelled()) && (steps.transport_test_ex_heap.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data heap_log_level_data
 
     - name: Run integration test [transport_test - Exercise mode - SHM-classic sub-mode]
       id: transport_test_ex_shm_c
       if: |
-        !cancelled()
+        false # XXX !cancelled()
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_classic -shm-c
 
     - name: Re-run with increased logging, on failure only
       if: |
-        (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
+        false # XXX (!cancelled()) && (steps.transport_test_ex_shm_c.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_classic_log_level_data -shm-c
 
     # Disabling this particular test run for the specific case of clang-17 in TSAN (thread sanitizer) config
@@ -1201,18 +1212,18 @@ jobs:
     - name: Run integration test [transport_test - Exercise mode - SHM-jemalloc sub-mode]
       id: transport_test_ex_shm_j
       if: |
-        (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
+        false # XXX (!cancelled()) && ((matrix.compiler.id != 'clang-17') || (matrix.build-test-cfg.sanitizer-name != 'tsan'))
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh info shm_jemalloc -shm-j
 
     - name: Re-run with increased logging, on failure only
       if: |
-        (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
+        false # XXX (!cancelled()) && (steps.transport_test_ex_shm_j.outcome == 'failure')
       run: /usr/bin/bash -e ${{ env.install-dir }}/bin/run_transport_test_ex.sh data shm_jemalloc_log_level_data -shm-j
 
     # See earlier comment block about why we saved all the logs including for console-output-only tests/demos.
     - name: Check test/demo logs for non-fatal sanitizer error(s)
       if: |
-        (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
+        false # XXX (!cancelled()) && (matrix.build-test-cfg.sanitizer-name == 'ubsan')
       run: |
         cd ${{ env.install-dir }}/bin/logs
         # grep returns 0 if 1+ found, 1 if none found, 2+ on error.  So check results explicitly instead of -e.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -421,42 +421,42 @@ jobs:
         #     be at least reduced.  In the meantime our *SAN coverage is still quite good.
         exclude:
           - build-test-cfg: { id: relwithdebinfo-msan }
-          - compiler:  { id: gcc-9 }
+          - compiler: { id: gcc-9 }
             build-test-cfg: { id: relwithdebinfo-asan }
-          - compiler:  { id: gcc-10 }
+          - compiler: { id: gcc-10 }
             build-test-cfg: { id: relwithdebinfo-asan }
-          - compiler:  { id: gcc-11 }
+          - compiler: { id: gcc-11 }
             build-test-cfg: { id: relwithdebinfo-asan }
-          - compiler:  { id: gcc-13 }
+          - compiler: { id: gcc-13 }
             build-test-cfg: { id: relwithdebinfo-asan }
-          - compiler:  { id: clang-13 }
+          - compiler: { id: clang-13 }
             build-test-cfg: { id: relwithdebinfo-asan }
-          - compiler:  { id: gcc-9 }
+          - compiler: { id: gcc-9 }
             build-test-cfg: { id: relwithdebinfo-ubsan }
-          - compiler:  { id: gcc-10 }
+          - compiler: { id: gcc-10 }
             build-test-cfg: { id: relwithdebinfo-ubsan }
-          - compiler:  { id: gcc-11 }
+          - compiler: { id: gcc-11 }
             build-test-cfg: { id: relwithdebinfo-ubsan }
-          - compiler:  { id: gcc-13 }
+          - compiler: { id: gcc-13 }
             build-test-cfg: { id: relwithdebinfo-ubsan }
-          - compiler:  { id: clang-13 }
+          - compiler: { id: clang-13 }
             build-test-cfg: { id: relwithdebinfo-ubsan }
-          - compiler:  { id: gcc-9 }
+          - compiler: { id: gcc-9 }
             build-test-cfg: { id: relwithdebinfo-tsan }
-          - compiler:  { id: gcc-10 }
+          - compiler: { id: gcc-10 }
             build-test-cfg: { id: relwithdebinfo-tsan }
-          - compiler:  { id: gcc-11 }
+          - compiler: { id: gcc-11 }
             build-test-cfg: { id: relwithdebinfo-tsan }
-          - compiler:  { id: gcc-13 }
+          - compiler: { id: gcc-13 }
             build-test-cfg: { id: relwithdebinfo-tsan }
-          - compiler:  { id: clang-13 }
+          - compiler: { id: clang-13 }
             build-test-cfg: { id: relwithdebinfo-tsan }
           # XXX
-          - compiler:  { id: gcc-9 }
-          - compiler:  { id: gcc-10 }
-          - compiler:  { id: gcc-11 }
-          - compiler:  { id: gcc-13 }
-          - compiler:  { id: clang-13 }
+          - compiler: { id: gcc-9 }
+          - compiler: { id: gcc-10 }
+          - compiler: { id: gcc-11 }
+          - compiler: { id: gcc-13 }
+          - compiler: { id: clang-13 }
           - build-test-cfg: { id: debug }
           - build-test-cfg: { id: relwithdebinfo }
           - build-test-cfg: { id: relwithdebinfo-asan }

--- a/test/suite/CMakeLists.txt
+++ b/test/suite/CMakeLists.txt
@@ -16,5 +16,5 @@
 # permissions and limitations under the License.
 
 add_subdirectory(perf_demo)
-# XXX add_subdirectory(transport_test)
-# XXX add_subdirectory(unit_test)
+add_subdirectory(transport_test)
+add_subdirectory(unit_test)

--- a/test/suite/CMakeLists.txt
+++ b/test/suite/CMakeLists.txt
@@ -16,5 +16,5 @@
 # permissions and limitations under the License.
 
 add_subdirectory(perf_demo)
-add_subdirectory(transport_test)
-add_subdirectory(unit_test)
+# XXX add_subdirectory(transport_test)
+# XXX add_subdirectory(unit_test)

--- a/test/suite/perf_demo/common.cpp
+++ b/test/suite/perf_demo/common.cpp
@@ -108,7 +108,7 @@ void setup_logging(std::optional<flow::log::Simple_ostream_logger>* std_logger,
   const auto log_file = (size_t(argc) > ARG_IDX) ? String_view(argv[ARG_IDX]) : String_view(LOG_FILE);
   FLOW_LOG_INFO("Opening log file [" << log_file << "] for IPC/Flow logs only.");
   static auto log_config = std_log_config;
-  log_config.configure_default_verbosity(Sev::S_INFO, true);//DATA, true);// XXX Sev::S_INFO, true);
+  log_config.configure_default_verbosity(Sev::S_INFO, true);
   log_logger->emplace(nullptr, &log_config, log_file, false /* No rotation; we're no serious business. */);
 }
 

--- a/test/suite/perf_demo/common.cpp
+++ b/test/suite/perf_demo/common.cpp
@@ -108,7 +108,7 @@ void setup_logging(std::optional<flow::log::Simple_ostream_logger>* std_logger,
   const auto log_file = (size_t(argc) > ARG_IDX) ? String_view(argv[ARG_IDX]) : String_view(LOG_FILE);
   FLOW_LOG_INFO("Opening log file [" << log_file << "] for IPC/Flow logs only.");
   static auto log_config = std_log_config;
-  log_config.configure_default_verbosity(Sev::S_DATA, true);// XXX Sev::S_INFO, true);
+  log_config.configure_default_verbosity(Sev::S_INFO, true);//DATA, true);// XXX Sev::S_INFO, true);
   log_logger->emplace(nullptr, &log_config, log_file, false /* No rotation; we're no serious business. */);
 }
 

--- a/test/suite/perf_demo/common.cpp
+++ b/test/suite/perf_demo/common.cpp
@@ -108,7 +108,7 @@ void setup_logging(std::optional<flow::log::Simple_ostream_logger>* std_logger,
   const auto log_file = (size_t(argc) > ARG_IDX) ? String_view(argv[ARG_IDX]) : String_view(LOG_FILE);
   FLOW_LOG_INFO("Opening log file [" << log_file << "] for IPC/Flow logs only.");
   static auto log_config = std_log_config;
-  log_config.configure_default_verbosity(Sev::S_INFO, true);
+  log_config.configure_default_verbosity(Sev::S_TRACE, true);// XXX Sev::S_INFO, true);
   log_logger->emplace(nullptr, &log_config, log_file, false /* No rotation; we're no serious business. */);
 }
 

--- a/test/suite/perf_demo/common.cpp
+++ b/test/suite/perf_demo/common.cpp
@@ -108,7 +108,7 @@ void setup_logging(std::optional<flow::log::Simple_ostream_logger>* std_logger,
   const auto log_file = (size_t(argc) > ARG_IDX) ? String_view(argv[ARG_IDX]) : String_view(LOG_FILE);
   FLOW_LOG_INFO("Opening log file [" << log_file << "] for IPC/Flow logs only.");
   static auto log_config = std_log_config;
-  log_config.configure_default_verbosity(Sev::S_TRACE, true);// XXX Sev::S_INFO, true);
+  log_config.configure_default_verbosity(Sev::S_DATA, true);// XXX Sev::S_INFO, true);
   log_logger->emplace(nullptr, &log_config, log_file, false /* No rotation; we're no serious business. */);
 }
 

--- a/test/suite/perf_demo/main_cli.cpp
+++ b/test/suite/perf_demo/main_cli.cpp
@@ -198,8 +198,10 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       FLOW_LOG_INFO("> Issuing get-cache request via tiny message.");
       m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.
       FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), \"capnp-raw\", Timer::real_clock_types(), 100); // Begin timing.");
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
-      FLOW_LOG_INFO("XXX - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
+      Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
+      if (sys_err_code) { throw Runtime_error(sys_err_code, "run_capnp_over_raw():on_sync():send_blob()"); }
+      FLOW_LOG_INFO("XXX 2.0 - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
       m_timer->checkpoint("sent request");
       FLOW_LOG_INFO("XXX - After: m_timer->checkpoint(\"sent request\");");
 

--- a/test/suite/perf_demo/main_cli.cpp
+++ b/test/suite/perf_demo/main_cli.cpp
@@ -197,13 +197,8 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
 
       FLOW_LOG_INFO("> Issuing get-cache request via tiny message.");
       m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.
-      FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), \"capnp-raw\", Timer::real_clock_types(), 100); // Begin timing.");
-      //Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
-      //if (sys_err_code) { throw Runtime_error(sys_err_code, "run_capnp_over_raw():on_sync():send_blob()"); }
-      FLOW_LOG_INFO("XXX 3.0 - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
       m_timer->checkpoint("sent request");
-      FLOW_LOG_INFO("XXX - After: m_timer->checkpoint(\"sent request\");");
 
       FLOW_LOG_INFO("< Expecting get-cache response fragment: capnp segment count.");
       m_chan.async_receive_blob(Blob_mutable(&m_n, sizeof(m_n)), &m_err_code, &m_sz,

--- a/test/suite/perf_demo/main_cli.cpp
+++ b/test/suite/perf_demo/main_cli.cpp
@@ -197,7 +197,7 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
 
       FLOW_LOG_INFO("> Issuing get-cache request via tiny message.");
       m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.
-      FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.");
+      FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), \"capnp-raw\", Timer::real_clock_types(), 100); // Begin timing.");
       m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
       FLOW_LOG_INFO("XXX - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
       m_timer->checkpoint("sent request");

--- a/test/suite/perf_demo/main_cli.cpp
+++ b/test/suite/perf_demo/main_cli.cpp
@@ -197,8 +197,11 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
 
       FLOW_LOG_INFO("> Issuing get-cache request via tiny message.");
       m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.
+      FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.");
       m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
+      FLOW_LOG_INFO("XXX - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
       m_timer->checkpoint("sent request");
+      FLOW_LOG_INFO("XXX - After: m_timer->checkpoint(\"sent request\");");
 
       FLOW_LOG_INFO("< Expecting get-cache response fragment: capnp segment count.");
       m_chan.async_receive_blob(Blob_mutable(&m_n, sizeof(m_n)), &m_err_code, &m_sz,

--- a/test/suite/perf_demo/main_cli.cpp
+++ b/test/suite/perf_demo/main_cli.cpp
@@ -198,10 +198,10 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       FLOW_LOG_INFO("> Issuing get-cache request via tiny message.");
       m_timer.emplace(get_logger(), "capnp-raw", Timer::real_clock_types(), 100); // Begin timing.
       FLOW_LOG_INFO("XXX - After: m_timer.emplace(get_logger(), \"capnp-raw\", Timer::real_clock_types(), 100); // Begin timing.");
-      Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
-      if (sys_err_code) { throw Runtime_error(sys_err_code, "run_capnp_over_raw():on_sync():send_blob()"); }
-      FLOW_LOG_INFO("XXX 2.0 - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
+      //Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
+      //if (sys_err_code) { throw Runtime_error(sys_err_code, "run_capnp_over_raw():on_sync():send_blob()"); }
+      FLOW_LOG_INFO("XXX 3.0 - After: m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));");
       m_timer->checkpoint("sent request");
       FLOW_LOG_INFO("XXX - After: m_timer->checkpoint(\"sent request\");");
 

--- a/test/suite/perf_demo/main_srv.cpp
+++ b/test/suite/perf_demo/main_srv.cpp
@@ -394,7 +394,7 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
         do
         {
           const auto chunk_sz = std::min(chunk_max_sz, m_n);
-          m_chan.send_blob(Blob_const(start, chunk_sz), sys_err_code);
+          m_chan.send_blob(Blob_const(start, chunk_sz), &sys_err_code);
           if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-3"); }
           start += chunk_sz;
           m_n -= chunk_sz;

--- a/test/suite/perf_demo/main_srv.cpp
+++ b/test/suite/perf_demo/main_srv.cpp
@@ -338,9 +338,9 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
        * client sends get-cache-request, but we're still setting something up after accepting the session;
        * so we only send the response once we're ready to do that; but client has already started timing. */
       FLOW_LOG_INFO("> Issuing handshake SYN for initialization sync.");
-      Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
-      if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():start()"); }
+      //Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
+      //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():start()"); }
 
       /* Receive a dummy message as a request signal.  Technically we should expect an actual capnp-encoded
        * (albeit small) GetCacheReq here; but we'll accept any message; in the big benchmark this detail does not
@@ -372,9 +372,9 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       const auto capnp_segs = g_capnp_msg.getSegmentsForOutput();
       m_n = capnp_segs.size();
       FLOW_LOG_INFO("> Sending get-cache response fragment: capnp segment count = [" << m_n << "].");
-      Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
-      if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()"); }
+      //Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
+      //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()"); }
       FLOW_LOG_INFO("> Sending get-cache response fragments x N: [seg size, seg content...].");
 
       /* Essentially (through Flow-IPC unstructured-transport layer) mostly do a bunch ~64k ::write()s.
@@ -387,15 +387,15 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       {
         const auto capnp_seg = capnp_segs[idx].asBytes();
         m_n = capnp_seg.size();
-        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
-        if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-2"); }
+        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
+        //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-2"); }
 
         auto start = capnp_seg.begin();
         do
         {
           const auto chunk_sz = std::min(chunk_max_sz, m_n);
-          m_chan.send_blob(Blob_const(start, chunk_sz), &sys_err_code);
-          if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-3"); }
+          m_chan.send_blob(Blob_const(start, chunk_sz));//, &sys_err_code);
+          //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-3"); }
           start += chunk_sz;
           m_n -= chunk_sz;
         }

--- a/test/suite/perf_demo/main_srv.cpp
+++ b/test/suite/perf_demo/main_srv.cpp
@@ -338,7 +338,9 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
        * client sends get-cache-request, but we're still setting something up after accepting the session;
        * so we only send the response once we're ready to do that; but client has already started timing. */
       FLOW_LOG_INFO("> Issuing handshake SYN for initialization sync.");
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
+      Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
+      if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():start()"); }
 
       /* Receive a dummy message as a request signal.  Technically we should expect an actual capnp-encoded
        * (albeit small) GetCacheReq here; but we'll accept any message; in the big benchmark this detail does not
@@ -370,7 +372,9 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       const auto capnp_segs = g_capnp_msg.getSegmentsForOutput();
       m_n = capnp_segs.size();
       FLOW_LOG_INFO("> Sending get-cache response fragment: capnp segment count = [" << m_n << "].");
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
+      Error_code sys_err_code;
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
+      if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()"); }
       FLOW_LOG_INFO("> Sending get-cache response fragments x N: [seg size, seg content...].");
 
       /* Essentially (through Flow-IPC unstructured-transport layer) mostly do a bunch ~64k ::write()s.
@@ -383,13 +387,15 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       {
         const auto capnp_seg = capnp_segs[idx].asBytes();
         m_n = capnp_seg.size();
-        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
+        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)), &sys_err_code);
+        if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-2"); }
 
         auto start = capnp_seg.begin();
         do
         {
           const auto chunk_sz = std::min(chunk_max_sz, m_n);
-          m_chan.send_blob(Blob_const(start, chunk_sz));
+          m_chan.send_blob(Blob_const(start, chunk_sz), sys_err_code);
+          if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-3"); }
           start += chunk_sz;
           m_n -= chunk_sz;
         }

--- a/test/suite/perf_demo/main_srv.cpp
+++ b/test/suite/perf_demo/main_srv.cpp
@@ -338,9 +338,7 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
        * client sends get-cache-request, but we're still setting something up after accepting the session;
        * so we only send the response once we're ready to do that; but client has already started timing. */
       FLOW_LOG_INFO("> Issuing handshake SYN for initialization sync.");
-      //Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
-      //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():start()"); }
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
 
       /* Receive a dummy message as a request signal.  Technically we should expect an actual capnp-encoded
        * (albeit small) GetCacheReq here; but we'll accept any message; in the big benchmark this detail does not
@@ -372,9 +370,7 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       const auto capnp_segs = g_capnp_msg.getSegmentsForOutput();
       m_n = capnp_segs.size();
       FLOW_LOG_INFO("> Sending get-cache response fragment: capnp segment count = [" << m_n << "].");
-      //Error_code sys_err_code;
-      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
-      //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()"); }
+      m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
       FLOW_LOG_INFO("> Sending get-cache response fragments x N: [seg size, seg content...].");
 
       /* Essentially (through Flow-IPC unstructured-transport layer) mostly do a bunch ~64k ::write()s.
@@ -387,15 +383,13 @@ void run_capnp_over_raw(flow::log::Logger* logger_ptr, Channel_raw* chan_ptr)
       {
         const auto capnp_seg = capnp_segs[idx].asBytes();
         m_n = capnp_seg.size();
-        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));//, &sys_err_code);
-        //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-2"); }
+        m_chan.send_blob(Blob_const(&m_n, sizeof(m_n)));
 
         auto start = capnp_seg.begin();
         do
         {
           const auto chunk_sz = std::min(chunk_max_sz, m_n);
-          m_chan.send_blob(Blob_const(start, chunk_sz));//, &sys_err_code);
-          //if (sys_err_code) { throw Runtime_error(sys_err_code, "XXXrun_capnp_over_raw():on_request():send_blob()-3"); }
+          m_chan.send_blob(Blob_const(start, chunk_sz));
           start += chunk_sz;
           m_n -= chunk_sz;
         }


### PR DESCRIPTION
fixes #123